### PR TITLE
Removed output formats other than HDF5+XDMF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ branches:
   
 notifications:
   email: false
-  slack: aices-pcm-cfd:ShncJAFCJzx48zt8hrXpRwGw
 
 before_install:
-- docker pull quay.io/fenicsproject/stable:current
+- docker pull zimmerman/phaseflow-fenics:latest
 
 group: deprecated-2017Q2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
   email: false
 
 before_install:
-- docker pull zimmerman/phaseflow-fenics:latest
+- docker pull zimmerman/fenics-h5py:latest
 
 group: deprecated-2017Q2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ notifications:
   email: false
 
 before_install:
-- docker pull zimmerman/fenics-h5py:latest
+- docker pull zimmerman/phaseflow-fenics:latest
 
 group: deprecated-2017Q2
 
 script:
-- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared quay.io/fenicsproject/stable:current "mpirun -n 2 python -m pytest -k '(not linearized) and (not adaptive) and (not _1d)'" 
-- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared quay.io/fenicsproject/stable:current "python -m pytest"
+- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared zimmerman/phaseflow-fenics:latest "mpirun -n 2 python -m pytest -k '(not linearized) and (not adaptive) and (not _1d)'" 
+- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared zimmerman/phaseflow-fenics:latest "python -m pytest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM quay.io/fenicsproject/stable:latest
 
-RUN pip install --user h5py
+RUN pip install h5py
+
+RUN git clone https://github.com/geo-fluid-dynamics/phaseflow-fenics.git
+
+RUN cd phaseflow-fenics && pip install . && cd ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/fenicsproject/stable:latest
+
+RUN pip install --user h5py
+
+RUN git clone https://github.com/geo-fluid-dynamics/phaseflow-fenics.git
+
+RUN cd phaseflow-fenics && pip install --user . && cd ~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
 FROM quay.io/fenicsproject/stable:latest
 
 RUN pip install --user h5py
-
-RUN git clone https://github.com/geo-fluid-dynamics/phaseflow-fenics.git
-
-RUN cd phaseflow-fenics && pip install --user . && cd ~

--- a/phaseflow/output.py
+++ b/phaseflow/output.py
@@ -1,8 +1,8 @@
 import helpers
 
-def write_solution(output_format, solution_files, W, _w, current_time):
+def write_solution(solution_files, W, _w, current_time):
 
-    helpers.print_once("Writing solution to "+output_format)
+    helpers.print_once("Writing solution to HDF5+XDMF")
     
     w = _w.leaf_node()
         
@@ -13,19 +13,8 @@ def write_solution(output_format, solution_files, W, _w, current_time):
     pressure.rename("p", "pressure")
     
     temperature.rename("theta", "temperature")
-
-    if (output_format is 'vtk') or (output_format is 'xdmf'):
         
-        for i, var in enumerate([velocity, pressure, temperature]):
-        
-            solution_files[i].write(var, current_time)
+    for i, var in enumerate([velocity, pressure, temperature]):
+    
+        solution_files[i].write(var, current_time)
             
-    elif output_format is 'table':
-    
-        ''' The following table output is just hacked on for the 1D Stefan Problem, not general at all.'''
-    
-        coordinates = W.tabulate_dof_coordinates()
-        
-        for i, x in enumerate(coordinates):
-        
-            solution_files[0].write(str(current_time)+", "+str(x)+", "+str(temperature(x))+"\n")

--- a/tests/test_1d_units.py
+++ b/tests/test_1d_units.py
@@ -11,7 +11,6 @@ def test_1d_output():
     
     w = phaseflow.run(
         output_dir = 'output/test_1D_output/',
-        output_format = 'table',
         Pr = 1.,
         Ste = 1.,
         g = [0.],

--- a/tests/test_stefan_problem_1d.py
+++ b/tests/test_stefan_problem_1d.py
@@ -71,7 +71,6 @@ def stefan_problem(Ste = 1.,
 
     w, mesh = phaseflow.run(
         output_dir = 'output/test_stefan_problem_Ste'+str(Ste).replace('.', 'p')+'/',
-        output_format = 'table',
         Pr = 1.,
         Ste = Ste,
         g = [0.],
@@ -89,7 +88,7 @@ def stefan_problem(Ste = 1.,
         newton_relative_tolerance = newton_relative_tolerance,
         final_time = final_time,
         time_step_bounds = dt,
-        output_times = (),
+        output_times = ('initial', 'final'),
         linearize = False)
         
     return w
@@ -186,7 +185,6 @@ def test_boundary_refinement():
     #
     w, mesh = phaseflow.run(
         output_dir = 'output/test_stefan_problem_refine_boundary/',
-        output_format = 'table',
         Pr = 1.,
         Ste = 1.,
         g = [0.],
@@ -253,7 +251,6 @@ def test_pci_refinement():
     #
     w, mesh = phaseflow.run(
         output_dir = 'output/test_stefan_problem_refine_pci/',
-        output_format = 'table',
         Pr = 1.,
         Ste = Ste,
         g = [0.],

--- a/tests/test_wang2010.py
+++ b/tests/test_wang2010.py
@@ -22,18 +22,16 @@ def verify_against_wang2010(w, mesh):
             assert(abs(ux - true_ux) < 2.e-2)
         
 
-def test_wang2010_natural_convection_air():
+def wang2010_natural_convection_air(output_dir='output/test_wang2010_natural_convection', final_time=10., restart=False):
 
-    wang2010_data = {'Ra': 1.e6, 'Pr': 0.71, 'x': 0.5, 'y': [0., 0.15, 0.35, 0.5, 0.65, 0.85, 1.], 'ux': [0.0000, -0.0649, -0.0194, 0.0000, 0.0194, 0.0649, 0.0000]}
-    
     m = 20
     
     w, mesh = phaseflow.run(
         Ste = 1.e16,
         mesh = fenics.UnitSquareMesh(m, m, 'crossed'),
         time_step_bounds = (1.e-3, 1.e-3, 10.),
-        final_time = 10.,
-        output_times = (),
+        final_time = final_time,
+        output_times = ('final',),
         stop_when_steady = True,
         linearize = True,
         initial_values_expression = (
@@ -45,7 +43,28 @@ def test_wang2010_natural_convection_air():
         {'subspace': 0, 'value_expression': ("0.", "0."), 'degree': 3, 'location_expression': "near(x[0],  0.) | near(x[0],  1.) | near(x[1], 0.) | near(x[1],  1.)", 'method': "topological"},
         {'subspace': 2, 'value_expression': "0.", 'degree': 2, 'location_expression': "near(x[0],  0.)", 'method': "topological"},
         {'subspace': 2, 'value_expression': "0.", 'degree': 2, 'location_expression': "near(x[0],  1.)", 'method': "topological"}],
-        output_dir = 'output/test_wang2010_natural_convection')
+        output_dir = output_dir,
+        restart = restart)
+        
+    return w, mesh
+        
+        
+def test_wang2010_natural_convection_air():
+    
+    w, mesh = wang2010_natural_convection_air()
+        
+    verify_against_wang2010(w, mesh)
+    
+    
+def test_wang2010_natural_convection_air_restart():
+    
+    m = 20
+        
+    output_dir = 'output/test_wang2010_natural_convection_restart'
+    
+    w, mesh = wang2010_natural_convection_air(output_dir=output_dir, final_time=0.5, restart=False)
+    
+    w, mesh = wang2010_natural_convection_air(output_dir=output_dir, final_time=10., restart=True)
         
     verify_against_wang2010(w, mesh)
 
@@ -151,5 +170,7 @@ def test_regression_natural_convection_water():
 if __name__=='__main__':
     
     test_wang2010_natural_convection_air()
+    
+    test_wang2010_natural_convection_air_restart()
     
     test_regression_natural_convection_water()

--- a/tests/test_wang2010.py
+++ b/tests/test_wang2010.py
@@ -22,7 +22,7 @@ def verify_against_wang2010(w, mesh):
             assert(abs(ux - true_ux) < 2.e-2)
         
 
-def wang2010_natural_convection_air(output_dir='output/test_wang2010_natural_convection', final_time=10., restart=False):
+def wang2010_natural_convection_air_linearized(output_dir='output/test_wang2010_natural_convection', final_time=10., restart=False):
 
     m = 20
     
@@ -49,22 +49,22 @@ def wang2010_natural_convection_air(output_dir='output/test_wang2010_natural_con
     return w, mesh
         
         
-def test_wang2010_natural_convection_air():
+def test_wang2010_natural_convection_air_linearized():
     
-    w, mesh = wang2010_natural_convection_air()
+    w, mesh = wang2010_natural_convection_air_linearized()
         
     verify_against_wang2010(w, mesh)
     
     
-def test_wang2010_natural_convection_air_restart():
+def test_wang2010_natural_convection_air_linearized_restart():
     
     m = 20
         
     output_dir = 'output/test_wang2010_natural_convection_restart'
     
-    w, mesh = wang2010_natural_convection_air(output_dir=output_dir, final_time=0.5, restart=False)
+    w, mesh = wang2010_natural_convection_air_linearized(output_dir=output_dir, final_time=0.5, restart=False)
     
-    w, mesh = wang2010_natural_convection_air(output_dir=output_dir, final_time=10., restart=True)
+    w, mesh = wang2010_natural_convection_air_linearized(output_dir=output_dir, final_time=10., restart=True)
         
     verify_against_wang2010(w, mesh)
 
@@ -91,7 +91,7 @@ def verify_regression_water(w, mesh):
             assert(abs(theta - true_theta) < 1.e-2)
 
             
-def test_regression_natural_convection_water():
+def test_regression_natural_convection_water_linearized():
     m = 10
 
     linearize = True
@@ -169,8 +169,8 @@ def test_regression_natural_convection_water():
 
 if __name__=='__main__':
     
-    test_wang2010_natural_convection_air()
+    test_wang2010_natural_convection_air_linearized()
     
-    test_wang2010_natural_convection_air_restart()
+    test_wang2010_natural_convection_air_linearized_restart()
     
-    test_regression_natural_convection_water()
+    test_regression_natural_convection_water_linearized()


### PR DESCRIPTION
VTK has been problematic, and does not support 1D (at least not with how fenics uses it). HDF5+XDMF handles 1D and 2D with grace! So now we don't need the VTK option or the "table" hack we had for 1D.