### PR TITLE
Removed mpirun from Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,4 @@ before_install:
 group: deprecated-2017Q2
 
 script:
-- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared zimmerman/phaseflow-fenics:latest "pip install --user --upgrade . && mpirun -n 2 python -m pytest -v -k '(not debug) and (not _1d)'" 
-- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared zimmerman/phaseflow-fenics:latest "pip install --user --upgrade . && python -m pytest -v -k '_1d and (not debug)'" 
+- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared zimmerman/phaseflow-fenics:latest "pip install --user --upgrade . && python -m pytest -v -k '(not debug)'" 


### PR DESCRIPTION
This is necessary because of the unresolved issue #64.