### PR TITLE
Simplify lid-driven cavity test

### DIFF
--- a/tests/test_ghia1982.py
+++ b/tests/test_ghia1982.py
@@ -35,7 +35,6 @@ def test_ghia1982_steady_lid_driven_cavity():
         mesh = fenics.UnitSquareMesh(fenics.dolfin.mpi_comm_world(), m, m, 'crossed'),
         end_time = 1.e12,
         time_step_size = 1.e12,
-        nlp_relative_tolerance = 1.e-4,
         liquid_viscosity = 0.01,
         gravity = (0., 0.),
         stefan_number = 1.e16,
@@ -43,9 +42,7 @@ def test_ghia1982_steady_lid_driven_cavity():
         initial_values_expression = (lid, "0.", "0.", "1."),
         boundary_conditions = [
             {'subspace': 0, 'value_expression': ("1.", "0."), 'degree': 3, 'location_expression': lid, 'method': 'topological'},
-            {'subspace': 0, 'value_expression': ("0.", "0."), 'degree': 3, 'location_expression': fixed_walls, 'method': 'topological'},
-            {'subspace': 1, 'value_expression': "0.", 'degree': 2, 'location_expression': bottom_left_corner, 'method': 'pointwise'},
-            {'subspace': 2, 'value_expression': "1.", 'degree': 2, 'location_expression': bottom_left_corner, 'method': 'pointwise'}])
+            {'subspace': 0, 'value_expression': ("0.", "0."), 'degree': 3, 'location_expression': fixed_walls, 'method': 'topological'}])
 
     verify_against_ghia1982(w, mesh)
 

--- a/tests/test_variable_viscosity.py
+++ b/tests/test_variable_viscosity.py
@@ -33,13 +33,13 @@ def test_variable_viscosity__nightly():
 
     ymin = -0.25
     
-    fixed_walls = "near(x[0],  0.) | near(x[0],  1.) | near(x[1],  '+str(ymin)+')"
+    fixed_walls = "near(x[0],  0.) | near(x[0],  1.) | near(x[1],  " + str(ymin) + ")"
 
     left_middle = "near(x[0], 0.) && near(x[1], 0.5)"
     
     output_dir = "output/test_variable_viscosity"
     
-    mesh = fenics.RectangleMesh(fenics.Point(0., ymin), fenics.Point(1., 1.), 20, 25, 'crossed')
+    mesh = fenics.RectangleMesh(fenics.Point(0., ymin), fenics.Point(1., 1.), 20, 25, "crossed")
     
     
     # Refine the initial PCI.
@@ -79,7 +79,7 @@ def test_variable_viscosity__nightly():
         regularization_smoothing_factor = 0.01,
         gravity = (0., 0.),
         stefan_number = 1.e16,
-        adaptive = True,
+        adaptive = False,
         output_dir = output_dir,
         initial_values_expression = (lid, "0.", "0.", "1. - 2.*(x[1] <= 0.)"),
         boundary_conditions = [


### PR DESCRIPTION
There's no need for the pressure or temperature BC's, since these are constrained by the initial values.