### PR TITLE
Cleaning up to match abstract for FEniCS 2018 conference.

### DIFF
--- a/phaseflow/core.py
+++ b/phaseflow/core.py
@@ -421,6 +421,11 @@ class ContinuousFunction:
         self.function = function
         
         self.derivative_function = derivative_function
+        
+    
+    def __call__(self, arg):
+        
+        return self.function(arg)
       
         
 class Point(fenics.Point):

--- a/phaseflow/pure.py
+++ b/phaseflow/pure.py
@@ -22,23 +22,23 @@ def make_mixed_element(mesh_ufl_cell, pressure_degree = 1, temperature_degree = 
 
 class PhaseDependentMaterialProperty(phaseflow.core.ContinuousFunction):
 
-    def __init__(self, semi_phasefield_mapping, liquid_value, solid_value):
+    def __init__(self, liquid_value, solid_value):
     
         P_L = fenics.Constant(liquid_value)
         
         P_S = fenics.Constant(solid_value)
         
-        phi = semi_phasefield_mapping.function
+        def P(semi_phasefield_mapping, T):
         
-        def P(T):
-        
+            phi = semi_phasefield_mapping.function
+            
             return P_L + (P_S - P_L)*phi(T)
         
-
-        dphi = semi_phasefield_mapping.derivative_function
         
-        def dP(T):
+        def dP(semi_phasefield_mapping, T):
         
+            dphi = semi_phasefield_mapping.derivative_function
+            
             return (P_S - P_L)*dphi(T)
             
         phaseflow.core.ContinuousFunction.__init__(self, function = P, derivative_function = dP)
@@ -153,8 +153,8 @@ class TanhSemiPhasefieldMapping(phaseflow.core.ContinuousFunction):
             return -sech((T_r - T)/r)**2/(2.*r)
             
         phaseflow.core.ContinuousFunction.__init__(self, function=phi, derivative_function=dphi)
-        
-
+    
+    
 class ConstantFunction(phaseflow.core.ContinuousFunction):
 
     def __init__(self, constant_value):

--- a/phaseflow/pure_with_constant_properties.py
+++ b/phaseflow/pure_with_constant_properties.py
@@ -91,7 +91,7 @@ class Model(phaseflow.core.Model):
         
         f_B = buoyancy.function
         
-        phi = semi_phasefield_mapping.function
+        phi = semi_phasefield_mapping
         
         gamma = fenics.Constant(penalty_parameter)
         
@@ -100,7 +100,6 @@ class Model(phaseflow.core.Model):
         mu_S = fenics.Constant(solid_viscosity)
         
         phase_dependent_viscosity = phaseflow.pure.PhaseDependentMaterialProperty(
-            semi_phasefield_mapping = semi_phasefield_mapping,
             liquid_value = mu_L,
             solid_value = mu_S)
         
@@ -123,7 +122,7 @@ class Model(phaseflow.core.Model):
         self.variational_form = (
             b(u, psi_p) - psi_p*gamma*p
             + dot(psi_u, 1./Delta_t*(u - u_n) + f_B(T))
-            + c(u, u, psi_u) + b(psi_u, p) + a(mu(T), u, psi_u)
+            + c(u, u, psi_u) + b(psi_u, p) + a(mu(phi,T), u, psi_u)
             + 1./Delta_t*psi_T*(T - T_n - 1./Ste*(phi(T) - phi(T_n)))
             + dot(grad(psi_T), 1./Pr*grad(T) - T*u)        
             )*dx
@@ -157,7 +156,7 @@ class Model(phaseflow.core.Model):
                 + dot(psi_u, 1./Delta_t*delta_u + delta_T*df_B(T_k))
                 + c(u_k, delta_u, psi_u) + c(delta_u, u_k, psi_u) 
                 + b(psi_u, delta_p) 
-                + a(delta_T*dmu(T_k), u_k, psi_u) + a(mu(T_k), delta_u, psi_u) 
+                + a(delta_T*dmu(phi, T_k), u_k, psi_u) + a(mu(phi, T_k), delta_u, psi_u) 
                 + 1./Delta_t*psi_T*delta_T*(1. - 1./Ste*dphi(T_k))
                 + dot(grad(psi_T), 1./Pr*grad(delta_T) - T_k*delta_u - delta_T*u_k)
                 )*dx


### PR DESCRIPTION
Made ContinuousFunction callable. Explicitly input the mapping phi(T) to the phase-dependent property function.