### PR TITLE
Remove Dockerfile. Have Travis install h5py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ notifications:
 
 before_install:
 - docker pull quay.io/fenicsproject/stable:latest
-- docker run -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared quay.io/fenicsproject/stable:latest "pip3 install --user h5py" 
 
 script:
-- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared quay.io/fenicsproject/stable:latest "python3 -m pytest -v -k '_ci_'" 
+- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared quay.io/fenicsproject/stable:latest "pip3 install --user h5py && python3 -m pytest -v -k '_ci_'" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-language: python
-
-python:
-  - "3.5"
-  
 services:
   - docker
 
@@ -14,7 +9,8 @@ notifications:
   email: false
 
 before_install:
-- docker pull zimmerman/phaseflow-fenics:latest
+- docker pull quay.io/fenicsproject/stable:latest
+- docker run -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared quay.io/fenicsproject/stable:latest "pip3 install --user h5py" 
 
 script:
-- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared zimmerman/phaseflow-fenics:latest "pip3 install --user -r requirements.txt && pip3 install --user --upgrade . && python3 -m pytest -v -k '_ci_'" 
+- docker run --rm -P -v `pwd`:/home/fenics/shared -w /home/fenics/shared quay.io/fenicsproject/stable:latest "python3 -m pytest -v -k '_ci_'" 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM quay.io/fenicsproject/stable:latest
-
-RUN pip3 install h5py
-
-RUN pip3 install pytest-dependency
-
-RUN git clone https://github.com/geo-fluid-dynamics/phaseflow-fenics.git
-
-RUN cd phaseflow-fenics && pip3 install . && cd ..


### PR DESCRIPTION
Maintaining our own Docker image was adding an unnecessary layer of complexity, and causing peculiar behavior in our continuous integration process. DockerHub does not make it very easy to see how images have changed.