### PR TITLE
Properties for parameters

### DIFF
--- a/phaseflow/abstract_phasechange_simulation.py
+++ b/phaseflow/abstract_phasechange_simulation.py
@@ -15,29 +15,30 @@ class AbstractPhaseChangeSimulation(phaseflow.abstract_simulation.AbstractSimula
     definitions for the mesh, initial values, and boundary conditions. """
     def __init__(self, time_order = 1, integration_measure = fenics.dx, setup_solver = True):
         
-        self.temperature_rayleigh_number = fenics.Constant(1., name = "Ra_T")
+        self._temperature_rayleigh_number = fenics.Constant(1., name = "Ra_T")
         
-        self.concentration_rayleigh_number = fenics.Constant(-1., name = "Ra_C")
+        self._concentration_rayleigh_number = fenics.Constant(-1., name = "Ra_C")
         
-        self.prandtl_number = fenics.Constant(1., name = "Pr")
+        self._prandtl_number = fenics.Constant(1., name = "Pr")
         
-        self.stefan_number = fenics.Constant(1., name = "Ste")
+        self._stefan_number = fenics.Constant(1., name = "Ste")
         
-        self.schmidt_number = fenics.Constant(1., name = "Sc")
+        self._schmidt_number = fenics.Constant(1., name = "Sc")
         
-        self.pure_liquidus_temperature = fenics.Constant(0., name = "T_m")
+        self._pure_liquidus_temperature = fenics.Constant(0., name = "T_m")
         
-        self.liquidus_slope = fenics.Constant(-1., name = "m_L")
+        self._liquidus_slope = fenics.Constant(-1., name = "m_L")
         
-        self.liquid_viscosity = fenics.Constant(1., name = "mu_L")
+        self._liquid_viscosity = fenics.Constant(1., name = "mu_L")
         
-        self.solid_viscosity = fenics.Constant(1.e8, name = "mu_S")
+        self._solid_viscosity = fenics.Constant(1.e8, name = "mu_S")
         
-        self.pressure_penalty_factor = fenics.Constant(1.e-7, name = "gamma")
+        self._pressure_penalty_factor = fenics.Constant(1.e-7, name = "gamma")
         
-        self.regularization_central_temperature_offset = fenics.Constant(0., name = "delta_T")
+        self._regularization_central_temperature_offset = fenics.Constant(
+            0., name = "delta_T")
         
-        self.regularization_smoothing_parameter = fenics.Constant(1./64., name = "r")
+        self._regularization_smoothing_parameter = fenics.Constant(1./64., name = "r")
     
         self.regularization_sequence = None
         
@@ -52,6 +53,76 @@ class AbstractPhaseChangeSimulation(phaseflow.abstract_simulation.AbstractSimula
         
             self.solver.parameters["newton_solver"]["absolute_tolerance"] = 1.e-9
     
+    @property
+    def temperature_rayleigh_number(self):
+    
+        return self._temperature_rayleigh_number
+    
+    @property
+    def concentration_rayleigh_number(self):
+    
+        return self._concentration_rayleigh_number
+        
+    @property
+    def prandtl_number(self):
+    
+        return self._prandtl_number
+        
+    @property
+    def stefan_number(self):
+    
+        return self._stefan_number
+    
+    @property
+    def schmidt_number(self):
+    
+        return self._schmidt_number
+        
+    @property
+    def prandtl_number(self):
+    
+        return self._prandtl_number
+        
+    @property
+    def pure_liquidus_temperature(self):
+    
+        return self._pure_liquidus_temperature
+        
+    @property
+    def liquidus_slope(self):
+    
+        return self._liquidus_slope
+        
+    @property
+    def prandtl_number(self):
+    
+        return self._prandtl_number
+        
+    @property
+    def liquid_viscosity(self):
+    
+        return self._liquid_viscosity
+        
+    @property
+    def solid_viscosity(self):
+    
+        return self._solid_viscosity
+        
+    @property
+    def pressure_penalty_factor(self):
+    
+        return self._pressure_penalty_factor
+    
+    @property
+    def regularization_central_temperature_offset(self):
+    
+        return self._regularization_central_temperature_offset
+        
+    @property
+    def regularization_smoothing_parameter(self):
+    
+        return self._regularization_smoothing_parameter
+        
     def phi(self, T, C, T_m, m_L, delta_T, s):
         """ The regularized semi-phasefield. """
         T_L = delta_T + T_m + m_L*C

--- a/phaseflow/abstract_phasechange_simulation.py
+++ b/phaseflow/abstract_phasechange_simulation.py
@@ -520,13 +520,13 @@ class AbstractPhaseChangeSimulation(phaseflow.abstract_simulation.AbstractSimula
         
         phi = fenics.project(self.semi_phasefield(T = T, C = C), mesh = self.mesh.leaf_node())
         
-        C = fenics.project(C*(1. - phi), mesh = self.mesh.leaf_node())
+        Cbar = fenics.project(C*(1. - phi), mesh = self.mesh.leaf_node())
        
         for var, label, colorbar, varname in zip(
-                (solution.function_space().mesh().leaf_node(), u, T, C, phi),
-                ("$\Omega_h$", "$\mathbf{u}$", "$T$", "$C$", "$\phi$"),
-                (False, True, True, True, True),
-                ("mesh", "u", "T", "C", "phi")):
+                (solution.function_space().mesh().leaf_node(), p, u, T, Cbar, phi),
+                ("$\Omega_h$", "$p$", "$\mathbf{u}$", "$T$", "$\overline{C}$", "$\phi$"),
+                (False, True, True, True, True, True),
+                ("mesh", "p", "u", "T", "Cbar", "phi")):
             
             some_mappable_thing = phaseflow.plotting.plot(var)
             

--- a/phaseflow/abstract_simulation.py
+++ b/phaseflow/abstract_simulation.py
@@ -68,6 +68,8 @@ class AbstractSimulation(metaclass = abc.ABCMeta):
         
         self.adaptive_solver = None
         
+        self.solver_status = {"iterations": 0, "solved": False}
+        
         self.solver_needs_setup = True
         
         if setup_solver:
@@ -214,7 +216,7 @@ class AbstractSimulation(metaclass = abc.ABCMeta):
         
         if goal_tolerance is None:
         
-            status = self.solver.solve()
+            solver_status = self.solver.solve()
             
         else:
             
@@ -222,9 +224,19 @@ class AbstractSimulation(metaclass = abc.ABCMeta):
                 self.adaptive_solver.parameters["nonlinear_variational_solver"],
                 self.solver.parameters)
                     
-            status = self.adaptive_solver.solve(goal_tolerance)
+            solver_status = self.adaptive_solver.solve(goal_tolerance)
             
-        return status
+        self.solver_status["iterations"] = solver_status[0]
+        
+        if solver_status[1]:
+        
+            self.solver_status["solved"] = True
+            
+        elif not solver_status[1]:
+        
+            self.solver_status["solved"] = False
+        
+        return solver_status
         
     def advance(self):
         """ Move solutions backward in the queue to prepare for a new time step. 

--- a/phaseflow/abstract_simulation.py
+++ b/phaseflow/abstract_simulation.py
@@ -79,12 +79,7 @@ class AbstractSimulation(metaclass = abc.ABCMeta):
     @property
     def timestep_size(self):
     
-        return self._timestep_sizes[0].values()[0]
-        
-    @timestep_size.setter
-    def timestep_size(self, value):
-    
-        self._timestep_sizes[0].assign(value)
+        return self._timestep_sizes[0]
     
     @property
     def mesh(self):
@@ -215,7 +210,7 @@ class AbstractSimulation(metaclass = abc.ABCMeta):
         
             self.setup_solver()
             
-        self._times[0] = self._times[1] + self.timestep_size
+        self._times[0] = self._times[1] + self.timestep_size.__float__()
         
         if goal_tolerance is None:
         

--- a/phaseflow/abstract_simulation.py
+++ b/phaseflow/abstract_simulation.py
@@ -218,25 +218,22 @@ class AbstractSimulation(metaclass = abc.ABCMeta):
         
             solver_status = self.solver.solve()
             
+            self.solver_status["iterations"] = solver_status[0]
+            
         else:
             
             share_solver_parameters(
                 self.adaptive_solver.parameters["nonlinear_variational_solver"],
                 self.solver.parameters)
                     
-            solver_status = self.adaptive_solver.solve(goal_tolerance)
+            self.adaptive_solver.solve(goal_tolerance)
             
-        self.solver_status["iterations"] = solver_status[0]
-        
-        if solver_status[1]:
-        
-            self.solver_status["solved"] = True
+            """ `fenics.AdaptiveNonlinearVariationalSolver` does not return status."""
+            self.solver_status["iterations"] = "NA"
             
-        elif not solver_status[1]:
+        self.solver_status["solved"] = True
         
-            self.solver_status["solved"] = False
-        
-        return solver_status
+        return self.solver_status
         
     def advance(self):
         """ Move solutions backward in the queue to prepare for a new time step. 

--- a/phaseflow/cavity_freezing_simulation.py
+++ b/phaseflow/cavity_freezing_simulation.py
@@ -86,7 +86,7 @@ class CavityFreezingSimulation(
             steady_q_tolerance = 0.01, 
             max_timesteps = 20):
         
-        Delta_t = self.timestep_size 
+        original_timestep_size = self.timestep_size.__float__()
         
         self.cold_wall_temperature.assign(self.cold_wall_temperature_before_freezing)
         
@@ -96,7 +96,7 @@ class CavityFreezingSimulation(
         
         self.set_constant_concentration(0.)
         
-        self.timestep_size = 1.e-3
+        self.timestep_size.assign(1.e-3)
         
         steady = False
         
@@ -118,13 +118,13 @@ class CavityFreezingSimulation(
                 
             q_old = 0. + q
             
-            self.timestep_size = 2.*self.timestep_size
+            self.timestep_size.assign(2.*self.timestep_size.__float__())
 
         assert(steady)
         
         self.set_constant_concentration(self.initial_concentration)
         
-        self.timestep_size = Delta_t
+        self.timestep_size.assign(original_timestep_size)
         
     def setup_freezing_problem(self):
         

--- a/phaseflow/cavity_freezing_simulation.py
+++ b/phaseflow/cavity_freezing_simulation.py
@@ -132,7 +132,7 @@ class CavityFreezingSimulation(
         
         self.regularization_central_temperature_offset.assign(0.)
         
-    def write_table_header(self, table_filepath):
+    def write_results_table_header(self, table_filepath):
         
         with open(table_filepath, "a") as table_file:
 
@@ -144,7 +144,7 @@ class CavityFreezingSimulation(
                 ", phi_min, phi_max" + \
                 "\n")
                 
-    def write_table_row(self, table_filepath):
+    def write_results_table_row(self, table_filepath):
     
         with open(table_filepath, "a") as table_file:
         
@@ -220,15 +220,17 @@ class CavityFreezingSimulation(
         
             self.plot(savefigs = savefigs)
         
-        table_filepath = self.output_dir + "Table.txt"
+        results_table_filepath = self.output_dir + "ResultsTable.txt"
         
-        print("Writing table to " + str(table_filepath))
+        print("Writing table to " + str(results_table_filepath))
         
-        self.write_table_header(table_filepath)
+        self.write_results_table_header(results_table_filepath)
+        
+        self.write_nonlinear_solver_table_header()
         
         if self.time == 0.:
             
-            self.write_table_row(table_filepath)
+            self.write_results_table_row(results_table_filepath)
         
         time_tolerance = 1.e-8
         
@@ -238,7 +240,7 @@ class CavityFreezingSimulation(
                 enable_newton_solution_backup = True,
                 max_attempts = max_regularization_attempts)
             
-            self.write_table_row(table_filepath)
+            self.write_results_table_row(results_table_filepath)
             
             with open(self.output_dir + "regularization_history.txt", "a") \
                     as regularization_history_file:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("LICENSE.txt") as f:
 
 setuptools.setup(
     name = "phaseflow",
-    version = "0.8.0-alpha",
+    version = "0.8.1-alpha",
     description = "Simulate convection-coupled melting and solidification of phase-change materials",
     long_description = readme,
     author= "Alexander G. Zimmerman",

--- a/tests/test_abstract_heated_cavity_phasechange_simulation.py
+++ b/tests/test_abstract_heated_cavity_phasechange_simulation.py
@@ -1,5 +1,6 @@
 import phaseflow
 import fenics
+import tempfile
 
 
 class HeatDrivenCavityBenchmarkSimulation(
@@ -527,6 +528,10 @@ def test__stefan_problem_with_bdf2__regression__ci__():
     expected_melted_length = 0.094662
     
     sim = StefanProblemBenchmarkSimulation(time_order = 2)
+    
+    sim.output_dir = tempfile.mkdtemp() + "/test__stefan_problem_with_bdf2/"
+    
+    phaseflow.helpers.mkdir_p(sim.output_dir)
     
     sim.assign_initial_values()
     

--- a/tests/test_abstract_heated_cavity_phasechange_simulation.py
+++ b/tests/test_abstract_heated_cavity_phasechange_simulation.py
@@ -22,7 +22,7 @@ class HeatDrivenCavityBenchmarkSimulation(
         
         self.cold_wall_temperature.assign(-0.5)
         
-        self.timestep_size = 1.e-3
+        self.timestep_size.assign(1.e-3)
         
         self.temperature_rayleigh_number.assign(1.e6)
         
@@ -128,7 +128,7 @@ def test__heat_driven_cavity__ci__():
             
             break
             
-        sim.timestep_size *= 2.
+        sim.timestep_size.assign(2.*sim.timestep_size.__float__())
         
     assert(steady)
     
@@ -147,47 +147,11 @@ class WaterHeatDrivenCavityBenchmarkSimulation(
             integration_measure = fenics.dx(metadata={"quadrature_degree":  8}),
             setup_solver = True):
         
-        self.hot_wall_temperature_degC = fenics.Constant(
-            10., name = "T_h_degC")
+        self.hot_wall_temperature_degC = 10.
         
-        self.cold_wall_temperature_degC = fenics.Constant(
-            0., name = "T_c_degC")
+        self.cold_wall_temperature_degC = 0.
         
-        self.pure_liquidus_temperature_degC = fenics.Constant(
-            0., name = "T_m_degC")
-        
-        self.pure_liquidus_temperature = self.T(
-            self.pure_liquidus_temperature_degC)
-        
-        class HotWall(fenics.SubDomain):
-
-            def inside(self, x, on_boundary):
-
-                return on_boundary and fenics.near(x[0], 0.)
-                
-        class ColdWall(fenics.SubDomain):
-
-            def inside(self, x, on_boundary):
-
-                return on_boundary and fenics.near(x[0], 1.)
-                
-        class Walls(fenics.SubDomain):
-
-            def inside(self, x, on_boundary):
-
-                return on_boundary
-
-        self._HotWall = HotWall
-        
-        self.hot_wall = self._HotWall()
-       
-        self._ColdWall = ColdWall
-        
-        self.cold_wall = self._ColdWall()
-        
-        self._Walls = Walls
-        
-        self.walls = self._Walls()
+        self.pure_liquidus_temperature_degC = 0.
         
         super().__init__(
             time_order = time_order, 
@@ -199,7 +163,8 @@ class WaterHeatDrivenCavityBenchmarkSimulation(
         self.prandtl_number.assign(6.99)
         
         """ Disable freezing. """
-        self.pure_liquidus_temperature.assign(0.)
+        self.pure_liquidus_temperature.assign(
+            self.T(self.pure_liquidus_temperature_degC))
         
         self.regularization_central_temperature_offset.assign(0.)
         
@@ -233,12 +198,6 @@ class WaterHeatDrivenCavityBenchmarkSimulation(
         T_m_degC = self.pure_liquidus_temperature_degC
 
         return T*(T_h_degC - T_c_degC) + T_m_degC
-        
-    def solve(self, goal_tolerance = None):
-        """ Validate parameters before solving. """
-        assert(self.pure_liquidus_temperature.__float__() == self.T(self.pure_liquidus_temperature_degC).__float__())
-        
-        super().solve(goal_tolerance = goal_tolerance)
         
     def buoyancy(self, T, C):
 
@@ -293,8 +252,8 @@ class WaterHeatDrivenCavityBenchmarkSimulation(
                  "0.", 
                  "(T_c - T_h)*x[0] + T_h", 
                  "0."),
-                T_h = self.T(self.hot_wall_temperature_degC).__float__(), 
-                T_c = self.T(self.cold_wall_temperature_degC).__float__(),
+                T_h = self.T(self.hot_wall_temperature_degC), 
+                T_c = self.T(self.cold_wall_temperature_degC),
                 element = self.element()),
             self.function_space)
             
@@ -309,11 +268,11 @@ class WaterHeatDrivenCavityBenchmarkSimulation(
                 self.walls),
             fenics.DirichletBC(
                 self.function_space.sub(2), 
-                self.T(self.hot_wall_temperature_degC).__float__(), 
+                self.T(self.hot_wall_temperature_degC),
                 self.hot_wall),
             fenics.DirichletBC(
                 self.function_space.sub(2), 
-                self.T(self.cold_wall_temperature_degC).__float__(), 
+                self.T(self.cold_wall_temperature_degC),
                 self.cold_wall)]
     
     def adaptive_goal(self):
@@ -346,7 +305,7 @@ def test__heat_driven_cavity_water__ci__():
 
     sim.assign_initial_values()
 
-    sim.timestep_size = 1.e-3
+    sim.timestep_size.assign(1.e-3)
 
     sim.solver.parameters["newton_solver"]["maximum_iterations"] = 8
 
@@ -358,13 +317,13 @@ def test__heat_driven_cavity_water__ci__():
 
         print("Solving time step number " + str(it))
 
-        sim.timestep_size = 2.*sim.timestep_size
+        sim.timestep_size.assign(2.*sim.timestep_size.__float__())
 
         for attempts in range(3):
 
             try:
 
-                print("Trying time step size " + str(sim.timestep_size))
+                print("Trying time step size " + str(sim.timestep_size.__float__()))
 
                 sim.solve(goal_tolerance = 0.05)
 
@@ -374,7 +333,7 @@ def test__heat_driven_cavity_water__ci__():
 
             except:
 
-                sim.timestep_size = sim.timestep_size/2.
+                sim.timestep_size.assign(sim.timestep_size.__float__()/2.)
 
                 sim.reset_initial_guess()
 
@@ -425,7 +384,7 @@ class StefanProblemBenchmarkSimulation(
         self.stefan_number.assign(0.045)
         
         
-        self.timestep_size = 1.e-3
+        self.timestep_size.assign(1.e-3)
         
         self.regularization_smoothing_parameter.assign(0.005)
         
@@ -550,7 +509,7 @@ def test__stefan_problem__ci__():
     
     timestep_count = 100
     
-    sim.timestep_size = end_time/float(timestep_count)
+    sim.timestep_size.assign(end_time/float(timestep_count))
     
     for it in range(timestep_count):
         
@@ -575,7 +534,7 @@ def test__stefan_problem_with_bdf2__regression__ci__():
     
     timestep_count = 25
     
-    sim.timestep_size = end_time/float(timestep_count)
+    sim.timestep_size.assign(end_time/float(timestep_count))
     
     sim.regularization_smoothing_parameter.assign(0.005)
     

--- a/tests/test_abstract_phasechange_simulation.py
+++ b/tests/test_abstract_phasechange_simulation.py
@@ -40,7 +40,7 @@ class LidDrivenCavityBenchmarkSimulation(phaseflow.abstract_phasechange_simulati
             integration_measure = integration_measure, 
             setup_solver = setup_solver)
         
-        self.timestep_size = 1.e12
+        self.timestep_size.assign(1.e12)
         
         self.temperature_rayleigh_number.assign(0.)
         

--- a/tests/test_cavity_freezing_simulation.py
+++ b/tests/test_cavity_freezing_simulation.py
@@ -26,7 +26,7 @@ def test__cavity_freezing_simulation__ci__():
     sim.output_dir = tempfile.mkdtemp() + "/test__cavity_freezing_simulation/"
     
     
-    sim.timestep_size = 1.
+    sim.timestep_size.assign(1.)
     
     endtime = 3.
     

--- a/tests/test_cavity_melting_simulation.py
+++ b/tests/test_cavity_melting_simulation.py
@@ -8,6 +8,11 @@ def test__compositional_convection_coupled_melting_benchmark__amr__regression__c
     
     sim = phaseflow.cavity_melting_simulation.CavityMeltingSimulation()
     
+    sim.output_dir = tempfile.mkdtemp() + \
+        "/test__compositional_convection_coupled_melting/"
+    
+    phaseflow.helpers.mkdir_p(sim.output_dir)
+    
     sim.assign_initial_values()
     
     sim.timestep_size.assign(10.)

--- a/tests/test_cavity_melting_simulation.py
+++ b/tests/test_cavity_melting_simulation.py
@@ -10,7 +10,7 @@ def test__compositional_convection_coupled_melting_benchmark__amr__regression__c
     
     sim.assign_initial_values()
     
-    sim.timestep_size = 10.
+    sim.timestep_size.assign(10.)
     
     for it, epsilon_M in zip(range(4), (0.5e-3, 0.25e-3, 0.125e-3, 0.0625e-3)):
     
@@ -71,7 +71,7 @@ class CavityMeltingSimulationWithoutConcentration(phaseflow.cavity_melting_simul
         self.liquidus_slope.assign(0.)
         
         
-        self.timestep_size = 10.
+        self.timestep_size.assign(10.)
         
         self.temperature_rayleigh_number.assign(3.27e5)
         


### PR DESCRIPTION
This prevents someone from inadvertently doing e.g. `sim.prandtl_number = 1`. instead of `sim.prandtl_number.assign(1.)`.

Also now the `CavityFreezingSimulation`...
- writes all parameters to the the results table
- writes a table showing the behavior of the nonlinear solver